### PR TITLE
Update ArgonSceneExporter.export_webgl method

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,17 @@ Usage::
  exporter.export()
 
 
+It is also possible to use the WebGL exporter to produce a JSON description of a Zinc scene without embedding it in an Argon document.
+This can be achieved with the :code:`export_webgl_from_scene` method. This method has one required parameter (:code:`scene`) and one
+optional parameter (:code:`scene_filter`). The :code:`scene` parameter is the Zinc Scene object to be exported. The :code:`scene_filter`
+parameter is a Zinc Scenefilter object associated with the Zinc scene and gives the user the option to filter which graphics are included
+in the export.
+
+Usage::
+
+ exporter = webgl.ArgonSceneExporter(output_target=output_directory)
+ exporter.export_webgl_from_scene(scene)
+
 Thumbnail
 ---------
 

--- a/src/cmlibs/exporter/webgl.py
+++ b/src/cmlibs/exporter/webgl.py
@@ -94,11 +94,14 @@ class ArgonSceneExporter(BaseExporter):
         return settings_obj
 
     def export_webgl(self):
+        scene = self._document.getRootRegion().getZincRegion().getScene()
+        self.export_webgl_from_scene(scene)
+
+    def export_webgl_from_scene(self, scene, scene_filter=None):
         """
         Export graphics into JSON format, one json export represents one
         surface graphics.
         """
-        scene = self._document.getRootRegion().getZincRegion().getScene()
         sceneSR = scene.createStreaminformationScene()
         sceneSR.setIOFormat(sceneSR.IO_FORMAT_THREEJS)
         if not (self._initialTime is None or self._finishTime is None):
@@ -108,6 +111,10 @@ class ArgonSceneExporter(BaseExporter):
             """ We want the geometries and colours change overtime """
             sceneSR.setOutputTimeDependentVertices(1)
             sceneSR.setOutputTimeDependentColours(1)
+
+        # Optionally filter the scene.
+        if scene_filter:
+            sceneSR.setScenefilter(scene_filter)
 
         number = sceneSR.getNumberOfResourcesRequired()
         if number == 0:
@@ -149,7 +156,7 @@ class ArgonSceneExporter(BaseExporter):
                     old_name = '"memory_resource_' + str(j + 2) + '"'
                     buffer = buffer.replace(old_name, replaceName, 1)
 
-                view_obj = self._define_default_view_obj()
+                view_obj = self._define_default_view_obj() if self._document else None
 
                 settings_obj = self._define_settings_obj()
 

--- a/src/cmlibs/exporter/webgl.py
+++ b/src/cmlibs/exporter/webgl.py
@@ -94,13 +94,19 @@ class ArgonSceneExporter(BaseExporter):
         return settings_obj
 
     def export_webgl(self):
+        """
+        Export graphics into JSON format, one json export represents one Zinc graphics.
+        """
         scene = self._document.getRootRegion().getZincRegion().getScene()
         self.export_webgl_from_scene(scene)
 
     def export_webgl_from_scene(self, scene, scene_filter=None):
         """
-        Export graphics into JSON format, one json export represents one
-        surface graphics.
+        Export graphics from a Zinc Scene into WebGL JSON format.
+
+        :param scene: The Zinc Scene object to be exported.
+        :param scene_filter: Optional; A Zinc Scenefilter object associated with the Zinc scene, allowing the user to filter which
+            graphics are included in the export.
         """
         sceneSR = scene.createStreaminformationScene()
         sceneSR.setIOFormat(sceneSR.IO_FORMAT_THREEJS)


### PR DESCRIPTION
A new method `export_webgl_from_scene` has been added to the `ArgonSceneExporter` class. This method works like `export_webgl` but takes an additional two arguments. Passing a `scene` argument allows the Zinc scene to be exported without actually creating an Argon document. The method also accepts an optional `scene_filter` argument, which gives the user the ability to filter which graphics are exported from the scene.

The `export_webgl` method now calls `export_webgl_from_scene` as an intermediate step but functions as before.